### PR TITLE
Feature: Notion sync and multi-territory civilization model

### DIFF
--- a/backend/Application/Interfaces/INotionSyncService.cs
+++ b/backend/Application/Interfaces/INotionSyncService.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+
+namespace Application.Interfaces
+{
+    public interface INotionSyncService
+    {
+        Task SyncFromNotionAsync(CancellationToken ct);
+    }
+}

--- a/backend/Application/Models/Dto/CivilizationDto.cs
+++ b/backend/Application/Models/Dto/CivilizationDto.cs
@@ -12,9 +12,7 @@ namespace Application.Models.Dto
 
         public string? ImageUrl { get; set; }
 
-        // public string? Summary { get; set; } //No se si se va a terminar utiliznaodo
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public TerritoryType Territory { get; set; }
+        public List<string> Territories { get; set; } = new();
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public CivilizationState State { get; set; }
@@ -26,8 +24,7 @@ namespace Application.Models.Dto
                 Id = civilization.Id,
                 Name = civilization.Name,
                 ImageUrl = civilization.ImageUrl,
-                //Summary = civilization.Summary,
-                Territory = civilization.Territory,
+                Territories = civilization.Territories.Select(ct => ct.Territory.Name).ToList(),
                 State = civilization.State
             };
         }
@@ -40,9 +37,7 @@ namespace Application.Models.Dto
         public string? Overview { get; set; }
         public string? ImageUrl { get; set; }
 
-        //Enums
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public TerritoryType? Territory { get; set; }
+        public List<string> Territories { get; set; } = new();
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public CivilizationState? State { get; set; }
@@ -61,7 +56,7 @@ namespace Application.Models.Dto
                 Name = civilization.Name,
                 Overview = civilization.Overview,
                 ImageUrl = civilization.ImageUrl,
-                Territory = civilization.Territory,
+                Territories = civilization.Territories.Select(ct => ct.Territory.Name).ToList(),
                 State = civilization.State,
                 //Relaciones
                 Characters = civilization.Characters.Select(c => CharacterDtoCard.ToDto(c)).ToList(),

--- a/backend/Application/Models/Request/BattleRequest.cs
+++ b/backend/Application/Models/Request/BattleRequest.cs
@@ -11,6 +11,10 @@ namespace Application.Models.Request
         public string Name { get; set; } = default!;
 
         public string? Date { get; set; }
+        public string? Summary { get; set; }
+        public string? DetailedDescription { get; set; }
+        public TerritoryType? Territory { get; set; }
+        public int? AgeId { get; set; }
 
         public static Battle ToEntity(BattleCreateRequest dto)
         {
@@ -18,6 +22,10 @@ namespace Application.Models.Request
             {
                 Name = dto.Name,
                 Date = dto.Date,
+                Summary = dto.Summary,
+                DetailedDescription = dto.DetailedDescription,
+                Territory = dto.Territory,
+                AgeId = dto.AgeId,
             };
         }
     }

--- a/backend/Application/Models/Request/CharacterRequest.cs
+++ b/backend/Application/Models/Request/CharacterRequest.cs
@@ -13,15 +13,25 @@ namespace Application.Models.Request
         public string? HonorificTitle { get; set; }
         public string? LifePeriod { get; set; }
         public RoleCharacter? Role { get; set; }
+        public string? Description { get; set; }
+        public string? ImageUrl { get; set; }
+        public string? Dynasty { get; set; }
+        public int? CivilizationId { get; set; }
+        public int? AgeId { get; set; }
 
         public static Character ToEntity(CharacterCreateRequest req)
         {
             return new Character
             {
                 Name = req.Name,
+                Description = req.Description,
                 HonorificTitle = req.HonorificTitle,
                 LifePeriod = req.LifePeriod,
+                Dynasty = req.Dynasty,
+                ImageUrl = req.ImageUrl,
                 Role = req.Role,
+                CivilizationId = req.CivilizationId,
+                AgeId = req.AgeId,
             };
         }
     }

--- a/backend/Application/Models/Request/CivilizationRequest.cs
+++ b/backend/Application/Models/Request/CivilizationRequest.cs
@@ -10,16 +10,23 @@ namespace Application.Models.Request
         [Required(AllowEmptyStrings = false, ErrorMessage = "El campo Nombre es obligatorio.")]
         public string Name { get; set; } = default!;
 
-        public TerritoryType Territory { get; set; } = TerritoryType.None;
         public CivilizationState State { get; set; } = CivilizationState.None;
+
+        public List<string>? Territories { get; set; }
+
+        public string? Summary { get; set; }
+        public string? Overview { get; set; }
+        public string? ImageUrl { get; set; }
 
         public static Civilization ToEntity(CreateCivilizationRequest req)
         {
             return new Civilization
             {
                 Name = req.Name,
-                Territory = req.Territory,
                 State = req.State,
+                Summary = req.Summary,
+                Overview = req.Overview,
+                ImageUrl = req.ImageUrl,
             };
         }
     }
@@ -33,8 +40,8 @@ namespace Application.Models.Request
         public string? Summary { get; set; }
         public string? Overview { get; set; }
         public string? ImageUrl { get; set; }
-        public TerritoryType? Territory { get; set; }
         public CivilizationState? State { get; set; }
+        public List<string>? Territories { get; set; }
 
         public static void ApplyToEntity(UpdateCivilizationRequest req, Civilization civilization)
         {
@@ -42,7 +49,6 @@ namespace Application.Models.Request
             if (req.Summary is not null) civilization.Summary = req.Summary;
             if (req.Overview is not null) civilization.Overview = req.Overview;
             if (req.ImageUrl is not null) civilization.ImageUrl = req.ImageUrl;
-            if (req.Territory is not null) civilization.Territory = req.Territory.Value;
             if (req.State is not null) civilization.State = req.State.Value;
         }
     }

--- a/backend/Application/Services/CivilizationService.cs
+++ b/backend/Application/Services/CivilizationService.cs
@@ -1,17 +1,24 @@
 ﻿using Application.Interfaces;
 using Application.Models.Dto;
 using Application.Models.Request;
+using Domain.Entities;
 using Domain.Interfaces;
+using Domain.Relations;
+using ITerritoryRepository = Domain.Interfaces.ITerritoryRepository;
 
 namespace Application.Services
 {
     public class CivilizationService : ICivilizationService
     {
         private readonly ICivilizationRepository _civilizationRepository;
+        private readonly ITerritoryRepository _territoryRepository;
 
-        public CivilizationService(ICivilizationRepository civilizationRepository)
+        public CivilizationService(
+            ICivilizationRepository civilizationRepository,
+            ITerritoryRepository territoryRepository)
         {
             _civilizationRepository = civilizationRepository;
+            _territoryRepository = territoryRepository;
         }
 
         public async Task<IEnumerable<CivilizationGalleryDto>> GetAllCivilization(CancellationToken ct)
@@ -31,6 +38,8 @@ namespace Application.Services
         {
             var civilization = CreateCivilizationRequest.ToEntity(request);
             await _civilizationRepository.CreateCivilization(civilization, ct);
+            await SetTerritoriesAsync(civilization, request.Territories, ct);
+            await _civilizationRepository.UpdateCivilization(civilization, ct);
             return CivilizationDetailDto.ToDto(civilization);
         }
 
@@ -42,6 +51,10 @@ namespace Application.Services
                 return false;
             }
             UpdateCivilizationRequest.ApplyToEntity(request, civilization);
+            if (request.Territories is not null)
+            {
+                await SetTerritoriesAsync(civilization, request.Territories, ct);
+            }
             await _civilizationRepository.UpdateCivilization(civilization, ct);
             return true;
         }
@@ -57,6 +70,42 @@ namespace Application.Services
             await _civilizationRepository.DeleteCivilization(civilization, ct);
 
             return true;
+        }
+
+        private async Task SetTerritoriesAsync(Civilization civilization, List<string>? territories, CancellationToken ct)
+        {
+            if (territories is null)
+            {
+                return;
+            }
+
+            var normalizedNames = territories
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var existingTerritories = await _territoryRepository.GetTerritoriesByNames(normalizedNames, ct);
+            var existingMap = existingTerritories
+                .ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
+
+            civilization.Territories.Clear();
+
+            foreach (var territoryName in normalizedNames)
+            {
+                if (!existingMap.TryGetValue(territoryName, out var territory))
+                {
+                    territory = await _territoryRepository.CreateTerritory(new Territory { Name = territoryName }, ct);
+                }
+
+                civilization.Territories.Add(new CivilizationTerritory
+                {
+                    Civilization = civilization,
+                    CivilizationId = civilization.Id,
+                    Territory = territory,
+                    TerritoryId = territory.Id
+                });
+            }
         }
     }
 }

--- a/backend/Application/Services/NotionSyncService.cs
+++ b/backend/Application/Services/NotionSyncService.cs
@@ -1,0 +1,596 @@
+using Application.Interfaces;
+using Application.Models.Request;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Interfaces;
+using Domain.Relations;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Application.Services
+{
+    public class NotionSyncService : INotionSyncService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+        private readonly ICharacterRepository _characterRepository;
+        private readonly IBattleRepository _battleRepository;
+        private readonly ICivilizationRepository _civilizationRepository;
+        private readonly IAgeRepository _ageRepository;
+        private readonly ITerritoryRepository _territoryRepository;
+
+        public NotionSyncService(
+            HttpClient httpClient,
+            IConfiguration configuration,
+            ICharacterRepository characterRepository,
+            IBattleRepository battleRepository,
+            ICivilizationRepository civilizationRepository,
+            IAgeRepository ageRepository,
+            ITerritoryRepository territoryRepository)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _characterRepository = characterRepository ?? throw new ArgumentNullException(nameof(characterRepository));
+            _battleRepository = battleRepository ?? throw new ArgumentNullException(nameof(battleRepository));
+            _civilizationRepository = civilizationRepository ?? throw new ArgumentNullException(nameof(civilizationRepository));
+            _ageRepository = ageRepository ?? throw new ArgumentNullException(nameof(ageRepository));
+            _territoryRepository = territoryRepository ?? throw new ArgumentNullException(nameof(territoryRepository));
+        }
+
+        public async Task SyncFromNotionAsync(CancellationToken ct)
+        {
+            var notionToken = _configuration["Notion:Secret"];
+            var databaseId = _configuration["Notion:DatabaseId"];
+
+            if (string.IsNullOrWhiteSpace(notionToken) || string.IsNullOrWhiteSpace(databaseId))
+            {
+                throw new InvalidOperationException("Notion integration is not configured. Configure Notion:Secret and Notion:DatabaseId in appsettings.");
+            }
+
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", notionToken);
+            _httpClient.DefaultRequestHeaders.Remove("Notion-Version");
+            _httpClient.DefaultRequestHeaders.Add("Notion-Version", "2022-06-28");
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"databases/{databaseId}/query")
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+
+            var response = await _httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+
+            using var stream = await response.Content.ReadAsStreamAsync(ct);
+            var queryResult = await JsonSerializer.DeserializeAsync<NotionQueryResult>(stream, GetJsonSerializerOptions(), ct);
+            if (queryResult?.Results == null)
+            {
+                return;
+            }
+
+            foreach (var page in queryResult.Results)
+            {
+                await SyncPageAsync(page, ct);
+            }
+        }
+
+        private async Task SyncPageAsync(NotionPage page, CancellationToken ct)
+        {
+            var name = page.GetTitle("Name") ?? page.GetTitle("Title");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            var entityType = page.GetSelect("EntityType")
+                ?? page.GetSelect("Type")
+                ?? page.GetSelect("Tipo")
+                ?? "Civilization";
+
+            switch (entityType.Trim().ToLowerInvariant())
+            {
+                case "character":
+                    await SyncCharacterAsync(page, name, ct);
+                    break;
+                case "battle":
+                    await SyncBattleAsync(page, name, ct);
+                    break;
+                case "civilization":
+                    await SyncCivilizationAsync(page, name, ct);
+                    break;
+                default:
+                    await SyncCivilizationAsync(page, name, ct);
+                    break;
+            }
+        }
+
+        private async Task SyncCharacterAsync(NotionPage page, string name, CancellationToken ct)
+        {
+            var role = ParseEnum<RoleCharacter>(page.GetSelect("Role"));
+            var ageId = await ResolveAgeIdAsync(page.GetSelect("Age"), ct);
+            var civilizationId = await ResolveCivilizationIdAsync(page.GetSelect("Civilization"), ct);
+            var description = page.GetText("Description");
+            var honorificTitle = page.GetText("HonorificTitle");
+            var lifePeriod = page.GetText("LifePeriod");
+            var dynasty = page.GetText("Dynasty");
+            var imageUrl = page.GetText("ImageUrl");
+
+            var existing = await _characterRepository.GetCharacterByName(name, ct);
+            if (existing is null)
+            {
+                var request = new CharacterCreateRequest
+                {
+                    Name = name,
+                    Description = description,
+                    HonorificTitle = honorificTitle,
+                    LifePeriod = lifePeriod,
+                    Dynasty = dynasty,
+                    ImageUrl = imageUrl,
+                    Role = role,
+                    AgeId = ageId,
+                    CivilizationId = civilizationId
+                };
+
+                await _characterRepository.CreateCharacter(CharacterCreateRequest.ToEntity(request), ct);
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(description)) existing.Description = description;
+            if (!string.IsNullOrWhiteSpace(honorificTitle)) existing.HonorificTitle = honorificTitle;
+            if (!string.IsNullOrWhiteSpace(lifePeriod)) existing.LifePeriod = lifePeriod;
+            if (!string.IsNullOrWhiteSpace(dynasty)) existing.Dynasty = dynasty;
+            if (!string.IsNullOrWhiteSpace(imageUrl)) existing.ImageUrl = imageUrl;
+            if (role is not null) existing.Role = role;
+            if (ageId.HasValue) existing.AgeId = ageId;
+            if (civilizationId.HasValue) existing.CivilizationId = civilizationId;
+
+            await _characterRepository.UpdateCharacter(existing, ct);
+        }
+
+        private async Task SyncBattleAsync(NotionPage page, string name, CancellationToken ct)
+        {
+            var battleDate = page.GetText("Date");
+            var summary = page.GetText("Summary");
+            var detailedDescription = page.GetText("DetailedDescription") ?? page.GetText("Description");
+            var territory = ParseEnum<TerritoryType>(page.GetSelect("Territory"));
+            var ageId = await ResolveAgeIdAsync(page.GetSelect("Age"), ct);
+
+            var existing = await _battleRepository.GetBattleByName(name, ct);
+            if (existing is null)
+            {
+                var request = new BattleCreateRequest
+                {
+                    Name = name,
+                    Date = battleDate,
+                    Summary = summary,
+                    DetailedDescription = detailedDescription,
+                    Territory = territory,
+                    AgeId = ageId
+                };
+
+                await _battleRepository.CreateBattle(BattleCreateRequest.ToEntity(request), ct);
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(battleDate)) existing.Date = battleDate;
+            if (!string.IsNullOrWhiteSpace(summary)) existing.Summary = summary;
+            if (!string.IsNullOrWhiteSpace(detailedDescription)) existing.DetailedDescription = detailedDescription;
+            if (territory is not null) existing.Territory = territory;
+            if (ageId.HasValue) existing.AgeId = ageId;
+
+            await _battleRepository.UpdateBattle(existing, ct);
+        }
+
+        private async Task SyncCivilizationAsync(NotionPage page, string name, CancellationToken ct)
+        {
+            var summary = page.GetText("Summary") ?? page.GetText("Description") ?? page.GetText("Overview");
+            var overview = page.GetText("Overview") ?? page.GetText("Description") ?? page.GetText("Summary");
+            var imageUrl = page.GetText("ImageUrl");
+            var state = ParseEnum<CivilizationState>(page.GetSelect("State"))
+                ?? ParseEnum<CivilizationState>(page.GetSelect("Estado"));
+
+            var territoryNames = page.GetMultiSelect("Regiones")
+                .Concat(page.GetMultiSelect("Regions"))
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var characterPageIds = page.GetRelationIds("Personajes").Concat(page.GetRelationIds("Characters")).ToList();
+            var agePageIds = page.GetRelationIds("Periodos").Concat(page.GetRelationIds("Ages")).ToList();
+            var battlePageIds = page.GetRelationIds("Batallas").Concat(page.GetRelationIds("Battles")).ToList();
+
+            var existing = await _civilizationRepository.GetCivilizationByName(name, ct);
+            Civilization civilization;
+            if (existing is null)
+            {
+                civilization = new Civilization
+                {
+                    Name = name,
+                    Summary = summary,
+                    Overview = overview,
+                    ImageUrl = imageUrl,
+                    State = state ?? CivilizationState.None
+                };
+                await _civilizationRepository.CreateCivilization(civilization, ct);
+            }
+            else
+            {
+                civilization = existing;
+                if (!string.IsNullOrWhiteSpace(summary)) civilization.Summary = summary;
+                if (!string.IsNullOrWhiteSpace(overview)) civilization.Overview = overview;
+                if (!string.IsNullOrWhiteSpace(imageUrl)) civilization.ImageUrl = imageUrl;
+                if (state is not null) civilization.State = state.Value;
+            }
+
+            await SetCivilizationTerritoriesAsync(civilization, territoryNames, ct);
+            await SetCivilizationCharacterRelationsAsync(civilization, characterPageIds, ct);
+            await SetCivilizationAgeRelationsAsync(civilization, agePageIds, ct);
+            await SetCivilizationBattleRelationsAsync(civilization, battlePageIds, ct);
+
+            await _civilizationRepository.UpdateCivilization(civilization, ct);
+        }
+
+        private async Task SetCivilizationTerritoriesAsync(Civilization civilization, List<string> territoryNames, CancellationToken ct)
+        {
+            if (!territoryNames.Any())
+            {
+                return;
+            }
+
+            var existingTerritories = await _territoryRepository.GetTerritoriesByNames(territoryNames, ct);
+            var existingMap = existingTerritories.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
+            civilization.Territories.Clear();
+
+            foreach (var territoryName in territoryNames)
+            {
+                if (!existingMap.TryGetValue(territoryName, out var territory))
+                {
+                    territory = await _territoryRepository.CreateTerritory(new Territory { Name = territoryName }, ct);
+                    existingMap[territoryName] = territory;
+                }
+
+                civilization.Territories.Add(new CivilizationTerritory
+                {
+                    Civilization = civilization,
+                    CivilizationId = civilization.Id,
+                    Territory = territory,
+                    TerritoryId = territory.Id
+                });
+            }
+        }
+
+        private async Task SetCivilizationCharacterRelationsAsync(Civilization civilization, List<string> pageIds, CancellationToken ct)
+        {
+            foreach (var relationId in pageIds.Distinct())
+            {
+                var characterPage = await FetchNotionPageAsync(relationId, ct);
+                var characterName = characterPage.GetTitle("Name") ?? characterPage.GetTitle("Title");
+                if (string.IsNullOrWhiteSpace(characterName))
+                {
+                    continue;
+                }
+
+                var existingCharacter = await _characterRepository.GetCharacterByName(characterName, ct);
+                if (existingCharacter is null)
+                {
+                    var character = new Character
+                    {
+                        Name = characterName,
+                        Description = characterPage.GetText("Description"),
+                        HonorificTitle = characterPage.GetText("HonorificTitle"),
+                        LifePeriod = characterPage.GetText("LifePeriod"),
+                        Dynasty = characterPage.GetText("Dynasty"),
+                        ImageUrl = characterPage.GetText("ImageUrl"),
+                        CivilizationId = civilization.Id,
+                        Role = ParseEnum<RoleCharacter>(characterPage.GetSelect("Role"))
+                    };
+
+                    await _characterRepository.CreateCharacter(character, ct);
+                    continue;
+                }
+
+                existingCharacter.CivilizationId = civilization.Id;
+                await _characterRepository.UpdateCharacter(existingCharacter, ct);
+            }
+        }
+
+        private async Task SetCivilizationAgeRelationsAsync(Civilization civilization, List<string> pageIds, CancellationToken ct)
+        {
+            foreach (var relationId in pageIds.Distinct())
+            {
+                var agePage = await FetchNotionPageAsync(relationId, ct);
+                var ageName = agePage.GetTitle("Name") ?? agePage.GetTitle("Title");
+                if (string.IsNullOrWhiteSpace(ageName))
+                {
+                    continue;
+                }
+
+                var existingAge = await _ageRepository.GetAgeByName(ageName, ct);
+                if (existingAge is null)
+                {
+                    var age = new Age
+                    {
+                        Name = ageName,
+                        Summary = agePage.GetText("Summary") ?? agePage.GetText("Description"),
+                        Overview = agePage.GetText("Overview"),
+                        Date = agePage.GetText("Date")
+                    };
+
+                    existingAge = await _ageRepository.CreateAge(age, ct);
+                }
+
+                if (!civilization.Ages.Any(ca => ca.AgeId == existingAge.Id))
+                {
+                    civilization.Ages.Add(new CivilizationAge
+                    {
+                        Civilization = civilization,
+                        CivilizationId = civilization.Id,
+                        Age = existingAge,
+                        AgeId = existingAge.Id
+                    });
+                }
+            }
+        }
+
+        private async Task SetCivilizationBattleRelationsAsync(Civilization civilization, List<string> pageIds, CancellationToken ct)
+        {
+            foreach (var relationId in pageIds.Distinct())
+            {
+                var battlePage = await FetchNotionPageAsync(relationId, ct);
+                var battleName = battlePage.GetTitle("Name") ?? battlePage.GetTitle("Title");
+                if (string.IsNullOrWhiteSpace(battleName))
+                {
+                    continue;
+                }
+
+                var existingBattle = await _battleRepository.GetBattleByName(battleName, ct);
+                if (existingBattle is null)
+                {
+                    var battle = new Battle
+                    {
+                        Name = battleName,
+                        Date = battlePage.GetText("Date"),
+                        Summary = battlePage.GetText("Summary"),
+                        DetailedDescription = battlePage.GetText("DetailedDescription") ?? battlePage.GetText("Description"),
+                        Territory = ParseEnum<TerritoryType>(battlePage.GetSelect("Territory")),
+                        AgeId = await ResolveAgeIdAsync(battlePage.GetSelect("Age"), ct)
+                    };
+
+                    existingBattle = await _battleRepository.CreateBattle(battle, ct);
+                }
+
+                if (!civilization.Battles.Any(cb => cb.BattleId == existingBattle.Id))
+                {
+                    civilization.Battles.Add(new CivilizationBattle
+                    {
+                        Civilization = civilization,
+                        CivilizationId = civilization.Id,
+                        Battle = existingBattle,
+                        BattleId = existingBattle.Id
+                    });
+                }
+            }
+        }
+
+        private async Task<NotionPage> FetchNotionPageAsync(string pageId, CancellationToken ct)
+        {
+            var response = await _httpClient.GetAsync($"pages/{pageId}", ct);
+            response.EnsureSuccessStatusCode();
+            using var stream = await response.Content.ReadAsStreamAsync(ct);
+            var notionPage = await JsonSerializer.DeserializeAsync<NotionPage>(stream, GetJsonSerializerOptions(), ct);
+            return notionPage ?? throw new InvalidOperationException($"No se pudo leer la página de Notion {pageId}.");
+        }
+
+        private async Task<int?> ResolveAgeIdAsync(string? ageName, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(ageName))
+            {
+                return null;
+            }
+
+            var normalized = ageName.Trim();
+            var existing = await _ageRepository.GetAgeByName(normalized, ct);
+            if (existing is not null)
+            {
+                return existing.Id;
+            }
+
+            var age = new Age
+            {
+                Name = normalized
+            };
+            var created = await _ageRepository.CreateAge(age, ct);
+            return created.Id;
+        }
+
+        private async Task<int?> ResolveCivilizationIdAsync(string? civilizationName, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(civilizationName))
+            {
+                return null;
+            }
+
+            var normalized = civilizationName.Trim();
+            var existing = await _civilizationRepository.GetCivilizationByName(normalized, ct);
+            if (existing is not null)
+            {
+                return existing.Id;
+            }
+
+            var civilization = new Civilization
+            {
+                Name = normalized,
+                Summary = string.Empty,
+                Overview = string.Empty
+            };
+
+            var created = await _civilizationRepository.CreateCivilization(civilization, ct);
+            return created.Id;
+        }
+
+        private static TEnum? ParseEnum<TEnum>(string? value)
+            where TEnum : struct, Enum
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return Enum.TryParse(value.Trim(), true, out TEnum result) ? result : null;
+        }
+
+        private static JsonSerializerOptions GetJsonSerializerOptions()
+        {
+            return new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            };
+        }
+
+        private sealed class NotionQueryResult
+        {
+            public List<NotionPage>? Results { get; set; }
+        }
+
+        private sealed class NotionPage
+        {
+            public string? Id { get; set; }
+            public Dictionary<string, JsonElement> Properties { get; set; } = new();
+
+            public string? GetTitle(string propertyName)
+            {
+                if (!Properties.TryGetValue(propertyName, out var property))
+                {
+                    return null;
+                }
+
+                if (property.TryGetProperty("title", out var titleElement))
+                {
+                    return GetPlainTextFromRichText(titleElement);
+                }
+
+                return null;
+            }
+
+            public string? GetText(string propertyName)
+            {
+                if (!Properties.TryGetValue(propertyName, out var property))
+                {
+                    return null;
+                }
+
+                if (property.TryGetProperty("rich_text", out var richTextElement))
+                {
+                    return GetPlainTextFromRichText(richTextElement);
+                }
+
+                if (property.TryGetProperty("title", out var titleElement))
+                {
+                    return GetPlainTextFromRichText(titleElement);
+                }
+
+                if (property.TryGetProperty("select", out var selectElement) && selectElement.TryGetProperty("name", out var nameElement))
+                {
+                    return nameElement.GetString();
+                }
+
+                return null;
+            }
+
+            public string? GetSelect(string propertyName)
+            {
+                if (!Properties.TryGetValue(propertyName, out var property))
+                {
+                    return null;
+                }
+
+                if (property.TryGetProperty("select", out var selectElement) && selectElement.TryGetProperty("name", out var nameElement))
+                {
+                    return nameElement.GetString();
+                }
+
+                return null;
+            }
+
+            public List<string> GetMultiSelect(string propertyName)
+            {
+                if (!Properties.TryGetValue(propertyName, out var property))
+                {
+                    return new List<string>();
+                }
+
+                if (!property.TryGetProperty("multi_select", out var multiSelectElement) || multiSelectElement.ValueKind != JsonValueKind.Array)
+                {
+                    return new List<string>();
+                }
+
+                var results = new List<string>();
+                foreach (var item in multiSelectElement.EnumerateArray())
+                {
+                    if (item.TryGetProperty("name", out var nameElement) && nameElement.ValueKind == JsonValueKind.String)
+                    {
+                        var name = nameElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(name))
+                        {
+                            results.Add(name.Trim());
+                        }
+                    }
+                }
+
+                return results;
+            }
+
+            public List<string> GetRelationIds(string propertyName)
+            {
+                if (!Properties.TryGetValue(propertyName, out var property))
+                {
+                    return new List<string>();
+                }
+
+                if (!property.TryGetProperty("relation", out var relationElement) || relationElement.ValueKind != JsonValueKind.Array)
+                {
+                    return new List<string>();
+                }
+
+                var results = new List<string>();
+                foreach (var item in relationElement.EnumerateArray())
+                {
+                    if (item.TryGetProperty("id", out var idElement) && idElement.ValueKind == JsonValueKind.String)
+                    {
+                        var id = idElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(id))
+                        {
+                            results.Add(id.Trim());
+                        }
+                    }
+                }
+
+                return results;
+            }
+
+            private static string? GetPlainTextFromRichText(JsonElement element)
+            {
+                if (element.ValueKind != JsonValueKind.Array)
+                {
+                    return null;
+                }
+
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (item.TryGetProperty("plain_text", out var plainText) && plainText.ValueKind == JsonValueKind.String)
+                    {
+                        var text = plainText.GetString();
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                            return text.Trim();
+                        }
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/backend/Domain/Entities/Civilization.cs
+++ b/backend/Domain/Entities/Civilization.cs
@@ -18,9 +18,6 @@ namespace Domain.Entities
         public string? Overview { get; set; }
         public string? ImageUrl { get; set; }
 
-        //Enums
-        public TerritoryType Territory { get; set; }
-
         public CivilizationState State { get; set; }
 
         //Relacion 1->N
@@ -30,6 +27,10 @@ namespace Domain.Entities
         //Relacion N->N con Age
         public ICollection<CivilizationAge> Ages { get; set; }
             = new List<CivilizationAge>();
+
+        //Relacion N->N con Territory
+        public ICollection<CivilizationTerritory> Territories { get; set; }
+            = new List<CivilizationTerritory>();
 
         //Relaciones N->N con Battle
         public ICollection<CivilizationBattle> Battles { get; set; }

--- a/backend/Domain/Entities/Territory.cs
+++ b/backend/Domain/Entities/Territory.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Domain.Relations;
+
+namespace Domain.Entities
+{
+    public class Territory
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; } = default!;
+
+        public ICollection<CivilizationTerritory> Civilizations { get; set; } = new List<CivilizationTerritory>();
+    }
+}

--- a/backend/Domain/Interfaces/IAgeRepository.cs
+++ b/backend/Domain/Interfaces/IAgeRepository.cs
@@ -8,6 +8,8 @@ namespace Domain.Interfaces
 
         Task<Age?> GetAgeDetailById(int id, CancellationToken ct);
 
+        Task<Age?> GetAgeByName(string name, CancellationToken ct);
+
         Task<Age?> GetTrackedAgeById(int id, CancellationToken ct);
 
         //Task<Battle?> GetBattleById(int battleId, CancellationToken ct);

--- a/backend/Domain/Interfaces/IBattleRepository.cs
+++ b/backend/Domain/Interfaces/IBattleRepository.cs
@@ -8,6 +8,8 @@ namespace Domain.Interfaces
 
         Task<Battle?> GetByIdBattle(int id, CancellationToken ct);
 
+        Task<Battle?> GetBattleByName(string name, CancellationToken ct);
+
         Task<Battle> CreateBattle(Battle battle, CancellationToken ct);
 
         Task UpdateBattle(Battle battle, CancellationToken ct);

--- a/backend/Domain/Interfaces/ICharacterRepository.cs
+++ b/backend/Domain/Interfaces/ICharacterRepository.cs
@@ -8,6 +8,8 @@ namespace Domain.Interfaces
 
         Task<Character?> GetCharacterById(int id, CancellationToken ct);
 
+        Task<Character?> GetCharacterByName(string name, CancellationToken ct);
+
         // Se elimina FindByIdAsync para simplificar.
 
         // Se añade el método para crear que faltaba.

--- a/backend/Domain/Interfaces/ICivilizationRepository.cs
+++ b/backend/Domain/Interfaces/ICivilizationRepository.cs
@@ -8,6 +8,8 @@ namespace Domain.Interfaces
 
         Task<Civilization?> GetCivizlizationById(int id, CancellationToken ct);
 
+        Task<Civilization?> GetCivilizationByName(string name, CancellationToken ct);
+
         Task<Civilization> CreateCivilization(Civilization civilization, CancellationToken ct);
 
         Task UpdateCivilization(Civilization civilization, CancellationToken ct);

--- a/backend/Domain/Interfaces/ITerritoryRepository.cs
+++ b/backend/Domain/Interfaces/ITerritoryRepository.cs
@@ -1,0 +1,13 @@
+using Domain.Entities;
+
+namespace Domain.Interfaces
+{
+    public interface ITerritoryRepository
+    {
+        Task<Territory?> GetTerritoryByName(string name, CancellationToken ct);
+
+        Task<List<Territory>> GetTerritoriesByNames(IEnumerable<string> names, CancellationToken ct);
+
+        Task<Territory> CreateTerritory(Territory territory, CancellationToken ct);
+    }
+}

--- a/backend/Domain/Relations/CivilizationTerritory.cs
+++ b/backend/Domain/Relations/CivilizationTerritory.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Domain.Entities;
+
+namespace Domain.Relations
+{
+    public class CivilizationTerritory
+    {
+        [ForeignKey("Territory")]
+        public int TerritoryId { get; set; }
+
+        public Territory Territory { get; set; } = new Territory();
+
+        [ForeignKey("Civilization")]
+        public int CivilizationId { get; set; }
+
+        public Civilization Civilization { get; set; } = new Civilization();
+    }
+}

--- a/backend/Infrastructure/ApplicationContext.cs
+++ b/backend/Infrastructure/ApplicationContext.cs
@@ -12,6 +12,7 @@ namespace Infrastructure
         public DbSet<Civilization> Civilizations { get; set; }
         public DbSet<Battle> Battles { get; set; }
         public DbSet<Age> Ages { get; set; }
+        public DbSet<Territory> Territories { get; set; }
 
         //Tablas de relaciones N->N
         public DbSet<CharacterBattle> CharacterBattles { get; set; }
@@ -19,6 +20,8 @@ namespace Infrastructure
         public DbSet<CivilizationBattle> CivilizationBattles { get; set; }
 
         public DbSet<CivilizationAge> CivilizationAges { get; set; }
+
+        public DbSet<CivilizationTerritory> CivilizationTerritories { get; set; }
 
         public ApplicationContext(DbContextOptions<ApplicationContext> options) : base(options)
         {
@@ -109,6 +112,22 @@ namespace Infrastructure
                 .HasOne(ca => ca.Age)
                 .WithMany(Age => Age.Civilizations)
                 .HasForeignKey(ca => ca.AgeId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            //Civilization N--N Territory
+            modelBuilder.Entity<CivilizationTerritory>()
+                .HasKey(ct => new { ct.CivilizationId, ct.TerritoryId });
+
+            modelBuilder.Entity<CivilizationTerritory>()
+                .HasOne(ct => ct.Civilization)
+                .WithMany(c => c.Territories)
+                .HasForeignKey(ct => ct.CivilizationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<CivilizationTerritory>()
+                .HasOne(ct => ct.Territory)
+                .WithMany(t => t.Civilizations)
+                .HasForeignKey(ct => ct.TerritoryId)
                 .OnDelete(DeleteBehavior.Cascade);
         }
     }

--- a/backend/Infrastructure/Repositories/AgeRepository.cs
+++ b/backend/Infrastructure/Repositories/AgeRepository.cs
@@ -44,6 +44,12 @@ namespace Infrastructure.Repositories
             return age;
         }
 
+        public async Task<Age?> GetAgeByName(string name, CancellationToken ct)
+        {
+            return await _context.Ages
+                .FirstOrDefaultAsync(a => a.Name.ToLower() == name.ToLower(), ct);
+        }
+
         public async Task UpdateAge(Age age, CancellationToken ct)
         {
             await _context.SaveChangesAsync(ct);

--- a/backend/Infrastructure/Repositories/BatlleRepository.cs
+++ b/backend/Infrastructure/Repositories/BatlleRepository.cs
@@ -38,6 +38,17 @@ namespace Infrastructure.Repositories
             return battle;
         }
 
+        public async Task<Battle?> GetBattleByName(string name, CancellationToken ct)
+        {
+            return await _context.Battles
+                .Include(b => b.Age)
+                .Include(b => b.Character)
+                    .ThenInclude(cb => cb.Character)
+                .Include(b => b.Civilization)
+                    .ThenInclude(cb => cb.Civilization)
+                .FirstOrDefaultAsync(b => b.Name.ToLower() == name.ToLower(), ct);
+        }
+
         public async Task UpdateBattle(Battle battle, CancellationToken ct)
         {
             await _context.SaveChangesAsync(ct);

--- a/backend/Infrastructure/Repositories/CharacterRepository.cs
+++ b/backend/Infrastructure/Repositories/CharacterRepository.cs
@@ -37,6 +37,16 @@ namespace Infrastructure.Repositories
             return character;
         }
 
+        public async Task<Character?> GetCharacterByName(string name, CancellationToken ct)
+        {
+            return await _context.Characters
+                .Include(c => c.Civilization)
+                .Include(c => c.Age)
+                .Include(c => c.Battles)
+                    .ThenInclude(cb => cb.Battle)
+                .FirstOrDefaultAsync(c => c.Name.ToLower() == name.ToLower(), ct);
+        }
+
         public async Task UpdateCharacter(Character character, CancellationToken ct)
         {
             await _context.SaveChangesAsync(ct);

--- a/backend/Infrastructure/Repositories/CivilizationRepository.cs
+++ b/backend/Infrastructure/Repositories/CivilizationRepository.cs
@@ -12,6 +12,8 @@ namespace Infrastructure.Repositories
         {
             return await _context.Civilizations
                 .AsNoTracking()
+                .Include(c => c.Territories)
+                    .ThenInclude(ct => ct.Territory)
                 .ToListAsync(ct);
         }
 
@@ -21,8 +23,14 @@ namespace Infrastructure.Repositories
                 .Include(c => c.Characters).ThenInclude(ch => ch.Age) //Ver mas de los pj
                 .Include(c => c.Ages).ThenInclude(ca => ca.Age) //Tabla intermedia
                 .Include(c => c.Battles).ThenInclude(cb => cb.Battle) //Tabla intermedia
-                .AsNoTracking()
+                .Include(c => c.Territories).ThenInclude(ct => ct.Territory)
                 .FirstOrDefaultAsync(c => c.Id == id, ct);
+        }
+
+        public async Task<Civilization?> GetCivilizationByName(string name, CancellationToken ct)
+        {
+            return await _context.Civilizations
+                .FirstOrDefaultAsync(c => c.Name.ToLower() == name.ToLower(), ct);
         }
 
         public async Task<Civilization> CreateCivilization(Civilization civilization, CancellationToken ct)

--- a/backend/Infrastructure/Repositories/TerritoryRepository.cs
+++ b/backend/Infrastructure/Repositories/TerritoryRepository.cs
@@ -1,0 +1,42 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories
+{
+    public class TerritoryRepository : ITerritoryRepository
+    {
+        private readonly ApplicationContext _context;
+
+        public TerritoryRepository(ApplicationContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public async Task<Territory?> GetTerritoryByName(string name, CancellationToken ct)
+        {
+            return await _context.Territories
+                .FirstOrDefaultAsync(t => t.Name.ToLower() == name.ToLower(), ct);
+        }
+
+        public async Task<List<Territory>> GetTerritoriesByNames(IEnumerable<string> names, CancellationToken ct)
+        {
+            var normalizedNames = names
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name.Trim().ToLower())
+                .Distinct()
+                .ToList();
+
+            return await _context.Territories
+                .Where(t => normalizedNames.Contains(t.Name.ToLower()))
+                .ToListAsync(ct);
+        }
+
+        public async Task<Territory> CreateTerritory(Territory territory, CancellationToken ct)
+        {
+            await _context.Territories.AddAsync(territory, ct);
+            await _context.SaveChangesAsync(ct);
+            return territory;
+        }
+    }
+}

--- a/backend/WebApplication1/Controllers/NotionSyncController.cs
+++ b/backend/WebApplication1/Controllers/NotionSyncController.cs
@@ -1,0 +1,37 @@
+using Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ForgottenEmpire.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class NotionSyncController : ControllerBase
+    {
+        private readonly INotionSyncService _notionSyncService;
+
+        public NotionSyncController(INotionSyncService notionSyncService)
+        {
+            _notionSyncService = notionSyncService ?? throw new ArgumentNullException(nameof(notionSyncService));
+        }
+
+        [HttpPost("sync")]
+        public async Task<IActionResult> Sync(CancellationToken ct)
+        {
+            try
+            {
+                await _notionSyncService.SyncFromNotionAsync(ct);
+                return Ok(new { message = "Notion sync ejecutado." });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        [HttpGet("health")]
+        public IActionResult Health()
+        {
+            return Ok(new { status = "Notion sync ready" });
+        }
+    }
+}

--- a/backend/WebApplication1/HostedServices/NotionSyncHostedService.cs
+++ b/backend/WebApplication1/HostedServices/NotionSyncHostedService.cs
@@ -1,0 +1,59 @@
+using Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ForgottenEmpire.HostedServices
+{
+    public class NotionSyncHostedService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<NotionSyncHostedService> _logger;
+        private readonly IConfiguration _configuration;
+
+        public NotionSyncHostedService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<NotionSyncHostedService> logger,
+            IConfiguration configuration)
+        {
+            _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var pollingSeconds = _configuration.GetValue<int>("Notion:PollingIntervalSeconds", 300);
+            _logger.LogInformation("Notion sync worker started. Polling every {PollingSeconds} seconds.", pollingSeconds);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var syncService = scope.ServiceProvider.GetRequiredService<INotionSyncService>();
+                    await syncService.SyncFromNotionAsync(stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error during Notion sync execution.");
+                }
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(pollingSeconds), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+
+            _logger.LogInformation("Notion sync worker is stopping.");
+        }
+    }
+}

--- a/backend/WebApplication1/Program.cs
+++ b/backend/WebApplication1/Program.cs
@@ -3,12 +3,14 @@ using Application.Interfaces;
 using Application.Services;
 using Domain.Interfaces;
 using ForgottenEmpires.Application.Services;
+using ForgottenEmpire.HostedServices;
 using Infrastructure;
 using Infrastructure.Repositories;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using System.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +30,12 @@ builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 
 builder.Services.AddEndpointsApiExplorer();
+
+builder.Services.AddHttpClient<INotionSyncService, NotionSyncService>(client =>
+{
+    client.BaseAddress = new Uri("https://api.notion.com/v1/");
+    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+});
 
 //  Swagger => A�adir un header de nombre Authorize con el siguiente valor Bearer
 builder.Services.AddSwaggerGen(setupAction =>
@@ -70,7 +78,7 @@ builder.Services.AddAuthentication("Bearer") //Especifica que el esquema de aute
             ValidAudience = builder.Configuration["Authentication:Audience"],
             IssuerSigningKey = new SymmetricSecurityKey(
                 Encoding.ASCII.GetBytes(
-                    builder.Configuration["Authentication:SecretForKey"]
+                    builder.Configuration["Authentication:SecretForKey"] ?? string.Empty
                 )
             )
         };
@@ -93,6 +101,7 @@ builder.Services.AddScoped<IAgeService, AgeService>();
 //Civilization
 builder.Services.AddScoped<ICivilizationRepository, CivilizationRepository>();
 builder.Services.AddScoped<ICivilizationService, CivilizationService>();
+builder.Services.AddScoped<ITerritoryRepository, TerritoryRepository>();
 
 // Battle
 builder.Services.AddScoped<IBattleRepository, BatlleRepository>();
@@ -101,6 +110,8 @@ builder.Services.AddScoped<IBattleService, BattleService>();
 //Character
 builder.Services.AddScoped<ICharacterRepository, CharacterRepository>();
 builder.Services.AddScoped<ICharacterService, CharacterService>();
+
+builder.Services.AddHostedService<NotionSyncHostedService>();
 
 var app = builder.Build();
 

--- a/backend/WebApplication1/appsettings.json
+++ b/backend/WebApplication1/appsettings.json
@@ -14,5 +14,10 @@
         "SecretForKey": "p7$Xw9!Lr2@Vq6^Zm4#Tn8&Yb1*Hc0+Jf5=Gd3_Qk7%Sa9?Wm2!Xv4^Zt8&Bn1*",
         "Issuer": "ForgottenEmpire",
         "Audience": "StandarUsers"
+    },
+    "Notion": {
+        "Secret": "",
+        "DatabaseId": "",
+        "PollingIntervalSeconds": 300
     }
 }

--- a/frontend/app/[entity]/[id]/page.tsx
+++ b/frontend/app/[entity]/[id]/page.tsx
@@ -1,0 +1,188 @@
+import { ageService } from "@/services/ageService"
+import { battleService } from "@/services/battleService"
+import { characterService } from "@/services/characterService"
+import { civilizationService } from "@/services/civilizationService"
+import { getMetadata } from "@/constants/metadata"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { ArrowLeft, Landmark, Sword, Users, Clock } from "lucide-react"
+import Link from "next/link"
+import KintsugiDivider from "@/components/KintsugiDivider"
+
+interface PageProps {
+  params: {
+    entity: string
+    id: string
+  }
+}
+
+const entityIcons: Record<string, any> = {
+  ages: Clock,
+  battles: Sword,
+  characters: Users,
+  civilizations: Landmark,
+}
+
+export default async function EntityDetailPage({ params }: PageProps) {
+  const { entity, id } = params
+  const numericId = parseInt(id)
+  
+  let data: any = null
+  let title = ""
+  let description = ""
+  let attributes: Record<string, any> = {}
+
+  try {
+    switch (entity) {
+      case 'ages':
+        data = await ageService.getById(numericId)
+        title = data?.name || "Era Desconocida"
+        description = data?.overview || data?.summary || ""
+        attributes = {
+          "Período": data?.date,
+        }
+        break
+      case 'battles':
+        data = await battleService.getById(numericId)
+        title = data?.name || "Batalla Desconocida"
+        description = data?.detailedDescription || data?.summary || ""
+        attributes = {
+          "Fecha": data?.date,
+          "Resultado": getMetadata("battle", "outcome", data?.outcome || 0),
+        }
+        break
+      case 'civilizations':
+        data = await civilizationService.getById(numericId)
+        title = data?.name || "Civilización Desconocida"
+        description = data?.overview || data?.summary || ""
+        attributes = {
+          "Estado Histórico": getMetadata("civilization", "state", data?.state || 0),
+          "Tipo de Territorio": getMetadata("civilization", "territory", data?.territory || 0),
+        }
+        break
+      case 'characters':
+        data = await characterService.getById(numericId)
+        title = data?.name || "Personaje Desconocido"
+        description = data?.description || ""
+        attributes = {
+          "Título Honorífico": data?.honorificTitle,
+          "Período de Vida": data?.lifePeriod,
+        }
+        break
+    }
+  } catch (error) {
+    console.error("Error fetching entity detail:", error)
+  }
+
+  if (!data) {
+    return (
+      <main className="min-h-screen marble-bg flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="font-serif text-3xl text-[#af944d] mb-4">Registro Histórico de No Encontrado</h1>
+          <Link href="/">
+            <Button variant="outline" className="btn-classical-secondary">
+              Regresar a los Archivos
+            </Button>
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  const Icon = entityIcons[entity] || Landmark
+
+  return (
+    <main className="min-h-screen marble-bg py-12 md:py-20">
+      <div className="max-w-6xl mx-auto px-4">
+        {/* Navigation */}
+        <div className="mb-12">
+          <Link href="/">
+            <Button variant="ghost" className="text-[#af944d] hover:text-[#e6d28a] hover:bg-transparent -ml-4 flex gap-2 font-serif uppercase tracking-widest text-xs">
+              <ArrowLeft className="h-4 w-4" /> Volver a la Cronología
+            </Button>
+          </Link>
+        </div>
+
+        {/* Hero Section */}
+        <div className="vt-card-container classical-card p-0 md:p-1 overflow-hidden relative mb-12">
+          <div className="bg-[#fdfaf3]/80 dark:bg-[#1a1816]/90 p-8 md:p-16 backdrop-blur-md">
+            <div className="flex flex-col md:flex-row gap-8 items-center md:items-start text-center md:text-left">
+              <div className="p-6 bg-amber-50 dark:bg-[#2d2a25] border border-[#af944d]/30 rounded-[2px] shrink-0 transform -rotate-3">
+                <Icon className="h-12 w-12 text-[#af944d]" />
+              </div>
+              <div className="flex-1">
+                <h1 className="font-serif text-5xl md:text-7xl text-slate-900 dark:text-[#e6d28a] mb-6 uppercase tracking-tight vt-entity-title leading-tight">
+                  {title}
+                </h1>
+                <div className="w-24 h-[1px] bg-[#af944d] mb-8 mx-auto md:mx-0" />
+                <p className="font-serif text-xl md:text-2xl italic text-[#af944d] dark:text-[#c4a962]">
+                  Archivo Oficial de la {entity.slice(0, -1).charAt(0).toUpperCase() + entity.slice(0, -1).slice(1)}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="absolute bottom-0 left-0 right-0">
+             <KintsugiDivider />
+          </div>
+        </div>
+
+        {/* Content Grid */}
+        <div className="detail-grid items-start">
+          {/* Narrative Column */}
+          <section className="space-y-8">
+            <h2 className="font-serif text-3xl text-slate-900 dark:text-[#e6d28a] flex items-center gap-4">
+              Visión General 
+              <span className="h-[1px] flex-1 bg-[#af944d]/20"></span>
+            </h2>
+            <div className="prose prose-slate dark:prose-invert max-w-none">
+              <p className="font-sans text-lg leading-loose text-slate-700 dark:text-[#b8b09d] first-letter:text-5xl first-letter:font-serif first-letter:mr-3 first-letter:float-left first-letter:text-[#af944d]">
+                {description}
+              </p>
+            </div>
+            
+            {/* Si es una era o batalla, podríamos añadir más bloques aquí en el futuro */}
+          </section>
+
+          {/* Technical Data Column */}
+          <aside className="space-y-8 sticky top-24">
+             <Card className="classical-card p-0">
+               <CardHeader className="bg-[#af944d]/5 border-b border-[#af944d]/10 py-6">
+                 <CardTitle className="font-serif text-xl uppercase tracking-widest text-[#af944d]">
+                   Ficha Técnica
+                 </CardTitle>
+               </CardHeader>
+               <CardContent className="p-8 space-y-8">
+                 {Object.entries(attributes).map(([key, value]) => {
+                   const isMetadata = typeof value === 'object' && value?.label;
+                   return (
+                     <div key={key} className="space-y-2">
+                       <span className="font-serif text-[11px] font-bold tracking-widest uppercase text-[#af944d]/60 mb-1 block">
+                         {key}
+                       </span>
+                       <div className="flex flex-col gap-2">
+                         <span className={`font-sans text-lg font-medium ${isMetadata ? 'text-slate-900 dark:text-[#e6d28a]' : 'text-slate-700 dark:text-white'}`}>
+                           {isMetadata ? value.label : (value || "Registro Pendiente")}
+                         </span>
+                         {isMetadata && value.desc && (
+                           <p className="text-xs text-slate-500 dark:text-muted-foreground italic border-l-2 border-[#af944d]/20 pl-3">
+                             {value.desc}
+                           </p>
+                         )}
+                       </div>
+                     </div>
+                   );
+                 })}
+                 
+                 <div className="pt-8 border-t border-[#af944d]/10">
+                    <p className="text-[10px] uppercase tracking-tighter text-slate-400 text-center font-sans">
+                      Autenticado por los registros de Forgotten Empires
+                    </p>
+                 </div>
+               </CardContent>
+             </Card>
+          </aside>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -915,11 +915,40 @@
     box-shadow: 0 6px 16px rgba(230, 210, 138, 0.25), 0 0 30px rgba(230, 210, 138, 0.3);
   }
 
-  .dark .btn-documentation-enhanced-aura:hover {
+    .dark .btn-documentation-enhanced-aura:hover {
     background: rgba(230, 210, 138, 0.1);
     color: #ffffff;
     text-shadow: 0 0 20px rgba(255, 255, 255, 0.9), 0 0 30px rgba(255, 255, 255, 0.7), 0 0 40px rgba(244, 232, 166, 0.5);
     border-color: #f4e8a6;
     transform: scale(1.05);
+  }
+
+  /* View Transitions API - Premium Morphing Names */
+  .vt-entity-title {
+    view-transition-name: entity-title;
+  }
+
+  .vt-card-container {
+    view-transition-name: card-container;
+  }
+
+  /* Detail View Specific Layouts */
+  .detail-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+
+  @media (min-width: 1024px) {
+    .detail-grid {
+      grid-template-columns: 1.5fr 1fr;
+    }
+  }
+
+  .historical-divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    margin: 2rem 0;
+    opacity: 0.5;
   }
 }

--- a/frontend/components/DataSection.tsx
+++ b/frontend/components/DataSection.tsx
@@ -140,11 +140,11 @@ export default function DataSection() {
               }
 
               return (
-                <Link href={`/${selectedEntity}/${item.id}`} key={item.id}>
-                  <Card className="classical-card group h-full flex flex-col justify-between">
+                <Link href={`/${selectedEntity}/${item.id}`} key={item.id} className="transition-transform duration-300">
+                  <Card className="classical-card group h-full flex flex-col justify-between vt-card-container">
                     <CardHeader className="pb-4 relative z-10 px-0 pt-0">
                       <div className="flex justify-between items-start gap-4 mb-3">
-                        <CardTitle className="font-serif text-2xl tracking-wide text-slate-900 dark:text-[#e6d28a] group-hover:text-[#af944d] dark:group-hover:text-[#ffed99] transition-colors duration-300 uppercase leading-none">
+                        <CardTitle className="font-serif text-2xl tracking-wide text-slate-900 dark:text-[#e6d28a] group-hover:text-[#af944d] dark:group-hover:text-[#ffed99] transition-colors duration-300 uppercase leading-none vt-entity-title">
                           {item.name}
                         </CardTitle>
                         

--- a/frontend/constants/metadata.ts
+++ b/frontend/constants/metadata.ts
@@ -1,0 +1,41 @@
+/**
+ * Metadata Engine: Historical Data Dictionary
+ * 
+ * Maps raw backend ID enumerations to human-readable concepts,
+ * descriptions, and aesthetic tokens (colors/icons).
+ */
+
+export const METADATA = {
+  civilization: {
+    state: {
+      0: { label: "Soberanía Unificada", desc: "Un poder centralizado que domina un territorio coherente.", color: "text-amber-600" },
+      1: { label: "Federación Regional", desc: "Coalición de estados o tribus bajo un mando común.", color: "text-blue-600" },
+      2: { label: "Fragmentación Noble", desc: "Poder dividido entre señores feudales con autonomía local.", color: "text-slate-500" },
+      3: { label: "Imperio Hegemónico", desc: "Dominio absoluto sobre múltiples culturas y vastas regiones.", color: "text-purple-600" },
+    },
+    territory: {
+      0: { label: "Continental", desc: "Vastas extensiones de tierra sin fronteras marítimas dominantes." },
+      1: { label: "Archipiélago", desc: "Nación dispersa en múltiples islas con alto poder naval." },
+      2: { label: "Ribereño", desc: "Desarrollo lineal a lo largo de grandes arterias fluviales." },
+      3: { label: "Montañoso", desc: "Fortalezas naturales y terrenos de difícil acceso." },
+    }
+  },
+  battle: {
+    outcome: {
+      0: { label: "Victoria Absoluta", desc: "Aniquilación completa o rendición incondicional del enemigo.", color: "text-emerald-600" },
+      1: { label: "Victoria Pírrica", desc: "Triunfo obtenido a un costo devastador para el vencedor.", color: "text-orange-500" },
+      2: { label: "Empate Táctico", desc: "Ningún bando logró sus objetivos primordiales sin pérdidas críticas.", color: "text-slate-400" },
+      3: { label: "Derrota Honrosa", desc: "Repliegue estratégico que permitió preservar el grueso de las fuerzas.", color: "text-red-600" },
+    }
+  },
+  // Fallback for unknown IDs
+  unknown: { label: "Archivo Desconocido", desc: "Dato perdido en el tiempo o aún no catalogado." }
+};
+
+export type MetadataCategory = keyof typeof METADATA;
+
+export const getMetadata = (category: string, subCategory: string, id: number | string) => {
+  const cat = (METADATA as any)[category];
+  if (!cat || !cat[subCategory]) return METADATA.unknown;
+  return cat[subCategory][id] || METADATA.unknown;
+};


### PR DESCRIPTION
- Added Notion sync service, controller endpoint, and polling hosted service
- Added support for Notion relation syncing for Civilizations, Characters, Battles, and Ages
- Converted Civilization territory from single enum to N:M Territory entity model
- Added Territory entity, repository, and relation join table CivilizationTerritory
- Extended repository interfaces and implementations for name-based lookups
- Updated DTOs and request models to support multi-territory lists
- Registered new services in Program.cs and added Notion config placeholders
- Included frontend detail / UI assets for entity page and metadata mapping